### PR TITLE
Refactor: Correct MainViewModel filename and decouple SchemaViewModel…

### DIFF
--- a/SdfTools/Services/DialogService.cs
+++ b/SdfTools/Services/DialogService.cs
@@ -1,0 +1,22 @@
+using System.Windows; // Required for MessageBox
+
+namespace SdfTools.Services
+{
+    public class DialogService : IDialogService
+    {
+        public void ShowMessage(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        public void ShowWarning(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
+        public void ShowError(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+}

--- a/SdfTools/Services/IDialogService.cs
+++ b/SdfTools/Services/IDialogService.cs
@@ -1,0 +1,9 @@
+namespace SdfTools.Services
+{
+    public interface IDialogService
+    {
+        void ShowMessage(string message, string title);
+        void ShowWarning(string message, string title);
+        void ShowError(string message, string title);
+    }
+}

--- a/SdfTools/ViewModels/MainViewModel.cs
+++ b/SdfTools/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using SdfTools.Abstracts;
+using SdfTools.Services; // Add this for DialogService
 using SdfTools.Utilities;
 using SdfTools.Views;
 
@@ -169,7 +170,8 @@ public class MainViewModel : ViewModelBase
         // Here is the logic to open the schema editor window
         var view = new SchemaEditor
         {
-            DataContext = new SchemaViewModel()
+            // Pass a new DialogService instance to SchemaViewModel
+            DataContext = new SchemaViewModel(new DialogService()) 
         };
         view.ShowDialog();
     }

--- a/SdfTools/ViewModels/SchemaViewModel.cs
+++ b/SdfTools/ViewModels/SchemaViewModel.cs
@@ -11,6 +11,7 @@ namespace SdfTools.ViewModels;
 public class SchemaViewModel : ViewModelBase
 {
     private readonly SchemaService _schemaService = new();
+    private readonly IDialogService _dialogService; // Add this
     private string? _schemaName;
     private string? _newAttributeName;
     private string? _selectedDataType;
@@ -41,8 +42,9 @@ public class SchemaViewModel : ViewModelBase
     public ICommand RemoveAttributeCommand { get; }
     public ICommand ValidateSchemaCommand { get; }
 
-    public SchemaViewModel()
+    public SchemaViewModel(IDialogService dialogService) // Modify constructor
     {
+        _dialogService = dialogService; // Add this
         AddAttributeCommand = new RelayCommand(AddAttribute);
         RemoveAttributeCommand = new RelayCommand<DataAttribute>(RemoveAttribute);
         ValidateSchemaCommand = new RelayCommand(ValidateSchema);
@@ -67,7 +69,7 @@ public class SchemaViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            MessageBox.Show(ex.Message, "Ошибка", MessageBoxButton.OK, MessageBoxImage.Error);
+            _dialogService.ShowError(ex.Message, "Ошибка");
         }
     }
 
@@ -83,11 +85,11 @@ public class SchemaViewModel : ViewModelBase
     {
         if (_schemaService.ValidateSchema(out string message))
         {
-            MessageBox.Show("Схема валидна!", "Успех", MessageBoxButton.OK, MessageBoxImage.Information);
+            _dialogService.ShowMessage("Схема валидна!", "Успех");
         }
         else
         {
-            MessageBox.Show(message, "Ошибка валидации", MessageBoxButton.OK, MessageBoxImage.Warning);
+            _dialogService.ShowWarning(message, "Ошибка валидации");
         }
     }
 


### PR DESCRIPTION
… from MessageBox.

This commit includes the following changes:

1.  I corrected a typo in the MainViewModel filename from MainVIewModel.cs to MainViewModel.cs for consistency.
2.  I refactored SchemaViewModel to use an IDialogService for displaying messages, decoupling it from direct System.Windows.MessageBox.Show calls.
    - I introduced an IDialogService interface.
    - I added a DialogService implementation using MessageBox.
    - I injected IDialogService into SchemaViewModel.
    - I updated MainViewModel to provide DialogService to SchemaViewModel.

These changes improve code maintainability and testability. I also performed project analysis and reporting which led to these modifications.